### PR TITLE
Change AMI and user data of Windows agents

### DIFF
--- a/lib/construct/jenkins/agent-ec2-fleet.ts
+++ b/lib/construct/jenkins/agent-ec2-fleet.ts
@@ -249,17 +249,7 @@ export class AgentEC2Fleet extends Construct {
     return new AgentEC2Fleet(scope, id, {
       machineImage: props.amiId
         ? ec2.MachineImage.genericWindows({ [cdk.Stack.of(scope).region]: props.amiId })
-        : // Lookup AMI ID of Windows Server from SSM public parameter.
-          // https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-public-parameters-ami.html#public-parameters-ami-windows
-          ec2.MachineImage.fromSsmParameter(
-            // EC2LaunchV2: for use 'enableOpenSsh' feature. https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch-v2-settings.html#ec2launch-v2-enableopenssh
-            // Windows_Server-2019: for use docker image of Unity editor based on Windows Server 2019 published by GamiCI. https://hub.docker.com/r/unityci/editor
-            // ContainersLatest: for use docker environment.
-            '/aws/service/ami-windows-latest/EC2LaunchV2-Windows_Server-2019-English-Full-ContainersLatest',
-            {
-              os: ec2.OperatingSystemType.WINDOWS,
-            },
-          ),
+        : ec2.MachineImage.latestWindows(ec2.WindowsVersion.WINDOWS_SERVER_2022_ENGLISH_FULL_CONTAINERSLATEST),
       userData: userData,
       rootVolumeDeviceName: '/dev/sda1',
       sshCredentialsId: 'instance-ssh-key-windows',
@@ -272,7 +262,7 @@ export class AgentEC2Fleet extends Construct {
             fsRoot: 'C:\\Jenkins',
           }),
       sshConnectTimeoutSeconds: props.sshConnectTimeoutSeconds ?? 60,
-      sshConnectMaxNumRetries: props.sshConnectMaxNumRetries ?? 20,
+      sshConnectMaxNumRetries: props.sshConnectMaxNumRetries ?? 30,
       sshConnectRetryWaitTime: props.sshConnectRetryWaitTime ?? 15,
       ...(props as AgentEC2FleetPropsBase),
     });

--- a/lib/construct/jenkins/resources/.dockerignore
+++ b/lib/construct/jenkins/resources/.dockerignore
@@ -1,1 +1,2 @@
 agent-userdata.sh
+agent-userdata-windows.yml

--- a/lib/construct/jenkins/resources/agent-userdata-windows.yml
+++ b/lib/construct/jenkins/resources/agent-userdata-windows.yml
@@ -42,12 +42,19 @@ tasks:
           Write-Output "create partition"
           $disk | New-Partition -DriveLetter $JENKINS_DRIVE -UseMaximumSize | Format-Volume -FileSystem NTFS -NewFileSystemLabel "Data"
         } else {
-          # Check online status of the disk
           if ($disk.IsOffline) {
-            # If the disk was offline for unknown reason, change it online and reload partition information
-            $disk | Set-Disk -IsOffline $False
+            # If the disk was offline for unknown reason, change it online and reload partition information.
+            Write-Output "Disk is offline, change to online."
+            $disk | Set-Disk -IsOffline $false
             Start-Sleep 5
+
+            $disk = Get-Disk | Where-Object {$_.SerialNumber -CLike "$serialNumber*"}
             $partitions = $disk | Get-Partition
+          }
+          if ($disk.IsReadOnly) {
+            # If the disk was read only for unknown reason, change it writable.
+            Write-Output "Disk is read only, change to writable."
+            $disk | Set-Disk -IsReadOnly $false
           }
 
           # Find drive for Jenkins

--- a/lib/construct/jenkins/resources/agent-userdata-windows.yml
+++ b/lib/construct/jenkins/resources/agent-userdata-windows.yml
@@ -35,14 +35,22 @@ tasks:
           $disk | Initialize-Disk -PartitionStyle MBR
         }
 
+        # Get partition information from the volume
         $partitions = $disk | Get-Partition
         if (-not $partitions) {
+          # If no partitions present, create a new partition and format it.
           Write-Output "create partition"
           $disk | New-Partition -DriveLetter $JENKINS_DRIVE -UseMaximumSize | Format-Volume -FileSystem NTFS -NewFileSystemLabel "Data"
         } else {
+          # Check online status of the disk
           if ($disk.IsOffline) {
+            # If the disk was offline for unknown reason, change it online and reload partition information
             $disk | Set-Disk -IsOffline $False
+            Start-Sleep 5
+            $partitions = $disk | Get-Partition
           }
+
+          # Find drive for Jenkins
           $jenkinsPartition = $partitions | Where-Object {$_.DriveLetter -eq $JENKINS_DRIVE}
           if ($jenkinsPartition) {
             Write-Output "drive $JENKINS_DRIVE already mounted"

--- a/lib/construct/jenkins/resources/agent-userdata-windows.yml
+++ b/lib/construct/jenkins/resources/agent-userdata-windows.yml
@@ -34,11 +34,15 @@ tasks:
           Write-Output "initialize raw disk"
           $disk | Initialize-Disk -PartitionStyle MBR
         }
+
         $partitions = $disk | Get-Partition
         if (-not $partitions) {
           Write-Output "create partition"
           $disk | New-Partition -DriveLetter $JENKINS_DRIVE -UseMaximumSize | Format-Volume -FileSystem NTFS -NewFileSystemLabel "Data"
         } else {
+          if ($disk.IsOffline) {
+            $disk | Set-Disk -IsOffline $False
+          }
           $jenkinsPartition = $partitions | Where-Object {$_.DriveLetter -eq $JENKINS_DRIVE}
           if ($jenkinsPartition) {
             Write-Output "drive $JENKINS_DRIVE already mounted"
@@ -54,10 +58,21 @@ tasks:
       [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
       iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
-      # install git and git-lfs
+      # Install git and git-lfs
       choco install git -y --no-progress
       choco install git-lfs -y --no-progress
 
-      # install java
+      # Install java
       choco install corretto17jdk --install-args INSTALLDIR="C:\Java" -y --no-progress
+
+      # Install Unity Hub
+      choco install unity-hub -y --no-progress
+
+      # Install Unity Editor
+      $unityVersion = '2021.3.26f1'
+      $unityVersionChangeset = 'a16dc32e0ff2'
+      & "$env:ProgramFiles\Unity Hub\Unity Hub.exe" -- --no-sandbox --headless install --version $unityVersion --changeset $unityVersionChangeset | Out-String -Stream
+
+      # Install iOS / Android Build Support
+      & "$env:ProgramFiles\Unity Hub\Unity Hub.exe" -- --no-sandbox --headless install-modules --version $unityVersion --module ios android --childModules | Out-String -Stream
 - task: enableOpenSsh

--- a/lib/jenkins-unity-build-stack.ts
+++ b/lib/jenkins-unity-build-stack.ts
@@ -154,7 +154,6 @@ export class JenkinsUnityBuildStack extends cdk.Stack {
         ec2.InstanceType.of(InstanceClass.M5A, InstanceSize.XLARGE),
         ec2.InstanceType.of(InstanceClass.M5N, InstanceSize.XLARGE),
         ec2.InstanceType.of(InstanceClass.M5, InstanceSize.XLARGE),
-        ec2.InstanceType.of(InstanceClass.M4, InstanceSize.XLARGE),
       ],
       name: 'windows-fleet',
       label: 'windows',

--- a/test/__snapshots__/jenkins-unity-build.test.ts.snap
+++ b/test/__snapshots__/jenkins-unity-build.test.ts.snap
@@ -842,7 +842,7 @@ exports[`Snapshot test 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.us-east-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-us-east-2:3730c481715b73c5091225097227efafd7e5923b1a922c094e3ced8f64a5ab85",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.us-east-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-us-east-2:8b220441740e064aaea571f967480aca5461a360a69042a15e1e2f739b047b9f",
             },
             "LinuxParameters": {
               "Capabilities": {},
@@ -2656,14 +2656,29 @@ tasks:
           $disk | Initialize-Disk -PartitionStyle MBR
         }
 
+        # Get partition information from the volume
         $partitions = $disk | Get-Partition
         if (-not $partitions) {
+          # If no partitions present, create a new partition and format it.
           Write-Output "create partition"
           $disk | New-Partition -DriveLetter $JENKINS_DRIVE -UseMaximumSize | Format-Volume -FileSystem NTFS -NewFileSystemLabel "Data"
         } else {
           if ($disk.IsOffline) {
-            $disk | Set-Disk -IsOffline $False
+            # If the disk was offline for unknown reason, change it online and reload partition information.
+            Write-Output "Disk is offline, change to online."
+            $disk | Set-Disk -IsOffline $false
+            Start-Sleep 5
+
+            $disk = Get-Disk | Where-Object {$_.SerialNumber -CLike "$serialNumber*"}
+            $partitions = $disk | Get-Partition
           }
+          if ($disk.IsReadOnly) {
+            # If the disk was read only for unknown reason, change it writable.
+            Write-Output "Disk is read only, change to writable."
+            $disk | Set-Disk -IsReadOnly $false
+          }
+
+          # Find drive for Jenkins
           $jenkinsPartition = $partitions | Where-Object {$_.DriveLetter -eq $JENKINS_DRIVE}
           if ($jenkinsPartition) {
             Write-Output "drive $JENKINS_DRIVE already mounted"

--- a/test/__snapshots__/jenkins-unity-build.test.ts.snap
+++ b/test/__snapshots__/jenkins-unity-build.test.ts.snap
@@ -64,8 +64,8 @@ exports[`Snapshot test 1`] = `
       "Default": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
     },
-    "SsmParameterValueawsserviceamiwindowslatestEC2LaunchV2WindowsServer2019EnglishFullContainersLatestC96584B6F00A464EAD1953AFF4B05118Parameter": {
-      "Default": "/aws/service/ami-windows-latest/EC2LaunchV2-Windows_Server-2019-English-Full-ContainersLatest",
+    "SsmParameterValueawsserviceamiwindowslatestWindowsServer2022EnglishFullContainersLatestC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-ContainersLatest",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
     },
   },
@@ -842,7 +842,7 @@ exports[`Snapshot test 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.us-east-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-us-east-2:33fe4e91a5f8317f89527c8deaf9aa20b7a3e35108a9cf5c783709f311cf90c3",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.us-east-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-us-east-2:3730c481715b73c5091225097227efafd7e5923b1a922c094e3ced8f64a5ab85",
             },
             "LinuxParameters": {
               "Capabilities": {},
@@ -2587,7 +2587,7 @@ diskutil apfs resizeContainer $APFSCONT 0
             },
           },
           "ImageId": {
-            "Ref": "SsmParameterValueawsserviceamiwindowslatestEC2LaunchV2WindowsServer2019EnglishFullContainersLatestC96584B6F00A464EAD1953AFF4B05118Parameter",
+            "Ref": "SsmParameterValueawsserviceamiwindowslatestWindowsServer2022EnglishFullContainersLatestC96584B6F00A464EAD1953AFF4B05118Parameter",
           },
           "KeyName": "TestStack-agent-ssh-key",
           "SecurityGroupIds": [
@@ -2655,11 +2655,15 @@ tasks:
           Write-Output "initialize raw disk"
           $disk | Initialize-Disk -PartitionStyle MBR
         }
+
         $partitions = $disk | Get-Partition
         if (-not $partitions) {
           Write-Output "create partition"
           $disk | New-Partition -DriveLetter $JENKINS_DRIVE -UseMaximumSize | Format-Volume -FileSystem NTFS -NewFileSystemLabel "Data"
         } else {
+          if ($disk.IsOffline) {
+            $disk | Set-Disk -IsOffline $False
+          }
           $jenkinsPartition = $partitions | Where-Object {$_.DriveLetter -eq $JENKINS_DRIVE}
           if ($jenkinsPartition) {
             Write-Output "drive $JENKINS_DRIVE already mounted"
@@ -2675,12 +2679,23 @@ tasks:
       [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
       iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
-      # install git and git-lfs
+      # Install git and git-lfs
       choco install git -y --no-progress
       choco install git-lfs -y --no-progress
 
-      # install java
+      # Install java
       choco install corretto17jdk --install-args INSTALLDIR="C:\\Java" -y --no-progress
+
+      # Install Unity Hub
+      choco install unity-hub -y --no-progress
+
+      # Install Unity Editor
+      $unityVersion = '2021.3.26f1'
+      $unityVersionChangeset = 'a16dc32e0ff2'
+      & "$env:ProgramFiles\\Unity Hub\\Unity Hub.exe" -- --no-sandbox --headless install --version $unityVersion --changeset $unityVersionChangeset | Out-String -Stream
+
+      # Install iOS / Android Build Support
+      & "$env:ProgramFiles\\Unity Hub\\Unity Hub.exe" -- --no-sandbox --headless install-modules --version $unityVersion --module ios android --childModules | Out-String -Stream
 - task: enableOpenSsh
 ",
           },

--- a/test/__snapshots__/jenkins-unity-build.test.ts.snap
+++ b/test/__snapshots__/jenkins-unity-build.test.ts.snap
@@ -2542,9 +2542,6 @@ diskutil apfs resizeContainer $APFSCONT 0
               {
                 "InstanceType": "m5.xlarge",
               },
-              {
-                "InstanceType": "m4.xlarge",
-              },
             ],
           },
         },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- AMI
  - EC2LaunchV2-Windows_Server-2019-English-Full-ContainersLatest -> Windows_Server-2022-English-Full-ContainersLatest
    (because we decided not to use GameCI's container images that depends on Windows Server 2019)
- User data
  - Check and change online status / write protection of data volume.
  - Install Unity Editor and iOS / Android build support.
- Instance Types
  - Remove m4 instance type
    (because data volumes mounted as Offline and Read-only at launch time on m4 instance)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
