### PR TITLE
Fix the required number of data volumes

### DIFF
--- a/lib/construct/jenkins/agent-ec2-fleet.ts
+++ b/lib/construct/jenkins/agent-ec2-fleet.ts
@@ -186,7 +186,7 @@ export class AgentEC2Fleet extends Construct {
 
     if (dataVolumeSize != null) {
       const kind = `${cdk.Stack.of(this).stackName}-${id}`;
-      const volumesPerAz = Math.floor(props.fleetMaxSize / subnets.length);
+      const volumesPerAz = Math.ceil(props.fleetMaxSize / subnets.length);
 
       // create a pool of EBS volumes
       subnets


### PR DESCRIPTION
*Issue #, if available:*

None.

Issue: When I change `fleetMaxSize` from 4 to 1, no data volume is attached to the agent server
    - fleetMaxSize: 1
    - number of subnets: 4
    - number of data volumes per AZ: `Math.floor(props.fleetMaxSize / subnets.length)` = 0
When `fleetMaxSize` is 1 and `number of subnets` is 4, the number of data volumes should be 1

*Description of changes:*

The data volume calculation should use `Math.ceil` instead of `Math.floor`. It can generate extra data volumes but I think it's better than shortage.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
